### PR TITLE
Store shard assignments as bitsets

### DIFF
--- a/.ci/auto-gen.sh
+++ b/.ci/auto-gen.sh
@@ -21,6 +21,18 @@ autogen_subdir_clear() {
     rm -f ${DIR}/*.go
 }
 
+proto_clear() {
+	for DIR in $SRC;
+	do
+		PROTOS="${DIR}/*.pb.go"
+		if ls $PROTOS &> /dev/null; then
+			for FILE in $(ls PROTOS); do
+				rm $FILE
+			done
+		fi
+	done	
+}
+
 mocks_clear() {
     for DIR in $SRC;
     do
@@ -102,6 +114,8 @@ set -e
 
 if [ "$2" = "generated/mocks" ]; then
     mocks_clear
+elif [ "$s" = "generated/proto" ]; then
+		proto_clear
 else
     autogen_clear $1
 fi

--- a/generated/proto/schema/schema.pb.go
+++ b/generated/proto/schema/schema.pb.go
@@ -14,7 +14,7 @@ It has these top-level messages:
 	DatabaseAdd
 	DatabaseProperties
 	Database
-	ClusterShardAssignment
+	ShardSet
 	ClusterProperties
 	Cluster
 	DatabaseChanges
@@ -124,17 +124,17 @@ func (*DatabaseProperties) ProtoMessage()    {}
 
 // Database defines a single database
 type Database struct {
-	Properties          *DatabaseProperties                `protobuf:"bytes,1,opt,name=properties" json:"properties,omitempty"`
-	CreatedAt           int64                              `protobuf:"varint,2,opt,name=created_at" json:"created_at,omitempty"`
-	LastUpdatedAt       int64                              `protobuf:"varint,3,opt,name=last_updated_at" json:"last_updated_at,omitempty"`
-	DecommissionedAt    int64                              `protobuf:"varint,4,opt,name=decommissioned_at" json:"decommissioned_at,omitempty"`
-	ReadCutoverTime     int64                              `protobuf:"varint,5,opt,name=read_cutover_time" json:"read_cutover_time,omitempty"`
-	WriteCutoverTime    int64                              `protobuf:"varint,6,opt,name=write_cutover_time" json:"write_cutover_time,omitempty"`
-	CutoverCompleteTime int64                              `protobuf:"varint,7,opt,name=cutover_complete_time" json:"cutover_complete_time,omitempty"`
-	Clusters            map[string]*Cluster                `protobuf:"bytes,8,rep,name=clusters" json:"clusters,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	ShardAssignments    map[string]*ClusterShardAssignment `protobuf:"bytes,9,rep,name=shard_assignments" json:"shard_assignments,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Version             int32                              `protobuf:"varint,10,opt,name=version" json:"version,omitempty"`
-	MappingRules        []*ClusterMappingRuleSet           `protobuf:"bytes,11,rep,name=mapping_rules" json:"mapping_rules,omitempty"`
+	Properties          *DatabaseProperties      `protobuf:"bytes,1,opt,name=properties" json:"properties,omitempty"`
+	CreatedAt           int64                    `protobuf:"varint,2,opt,name=created_at" json:"created_at,omitempty"`
+	LastUpdatedAt       int64                    `protobuf:"varint,3,opt,name=last_updated_at" json:"last_updated_at,omitempty"`
+	DecommissionedAt    int64                    `protobuf:"varint,4,opt,name=decommissioned_at" json:"decommissioned_at,omitempty"`
+	ReadCutoverTime     int64                    `protobuf:"varint,5,opt,name=read_cutover_time" json:"read_cutover_time,omitempty"`
+	WriteCutoverTime    int64                    `protobuf:"varint,6,opt,name=write_cutover_time" json:"write_cutover_time,omitempty"`
+	CutoverCompleteTime int64                    `protobuf:"varint,7,opt,name=cutover_complete_time" json:"cutover_complete_time,omitempty"`
+	Clusters            map[string]*Cluster      `protobuf:"bytes,8,rep,name=clusters" json:"clusters,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	ShardAssignments    map[string]*ShardSet     `protobuf:"bytes,9,rep,name=shard_assignments" json:"shard_assignments,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Version             int32                    `protobuf:"varint,10,opt,name=version" json:"version,omitempty"`
+	MappingRules        []*ClusterMappingRuleSet `protobuf:"bytes,11,rep,name=mapping_rules" json:"mapping_rules,omitempty"`
 }
 
 func (m *Database) Reset()         { *m = Database{} }
@@ -155,7 +155,7 @@ func (m *Database) GetClusters() map[string]*Cluster {
 	return nil
 }
 
-func (m *Database) GetShardAssignments() map[string]*ClusterShardAssignment {
+func (m *Database) GetShardAssignments() map[string]*ShardSet {
 	if m != nil {
 		return m.ShardAssignments
 	}
@@ -169,14 +169,14 @@ func (m *Database) GetMappingRules() []*ClusterMappingRuleSet {
 	return nil
 }
 
-// ClusterShardAssignment captures the shards currently assigned to a cluster
-type ClusterShardAssignment struct {
-	Shards []uint32 `protobuf:"varint,1,rep,name=shards" json:"shards,omitempty"`
+// ShardSet is a bitset of shards
+type ShardSet struct {
+	Bits []uint64 `protobuf:"varint,1,rep,name=bits" json:"bits,omitempty"`
 }
 
-func (m *ClusterShardAssignment) Reset()         { *m = ClusterShardAssignment{} }
-func (m *ClusterShardAssignment) String() string { return proto.CompactTextString(m) }
-func (*ClusterShardAssignment) ProtoMessage()    {}
+func (m *ShardSet) Reset()         { *m = ShardSet{} }
+func (m *ShardSet) String() string { return proto.CompactTextString(m) }
+func (*ShardSet) ProtoMessage()    {}
 
 // ClusterProperties are the user specifiable properties for a Cluster
 type ClusterProperties struct {
@@ -258,27 +258,41 @@ func (*ClusterDecommission) ProtoMessage()    {}
 
 // CutoverRule is a rule transition shards onto a given cluster
 type CutoverRule struct {
-	ClusterName      string   `protobuf:"bytes,1,opt,name=cluster_name" json:"cluster_name,omitempty"`
-	Shards           []uint32 `protobuf:"varint,2,rep,name=shards" json:"shards,omitempty"`
-	ReadCutoverTime  int64    `protobuf:"varint,3,opt,name=read_cutover_time" json:"read_cutover_time,omitempty"`
-	WriteCutoverTime int64    `protobuf:"varint,4,opt,name=write_cutover_time" json:"write_cutover_time,omitempty"`
+	ClusterName      string    `protobuf:"bytes,1,opt,name=cluster_name" json:"cluster_name,omitempty"`
+	Shards           *ShardSet `protobuf:"bytes,2,opt,name=shards" json:"shards,omitempty"`
+	ReadCutoverTime  int64     `protobuf:"varint,3,opt,name=read_cutover_time" json:"read_cutover_time,omitempty"`
+	WriteCutoverTime int64     `protobuf:"varint,4,opt,name=write_cutover_time" json:"write_cutover_time,omitempty"`
 }
 
 func (m *CutoverRule) Reset()         { *m = CutoverRule{} }
 func (m *CutoverRule) String() string { return proto.CompactTextString(m) }
 func (*CutoverRule) ProtoMessage()    {}
 
+func (m *CutoverRule) GetShards() *ShardSet {
+	if m != nil {
+		return m.Shards
+	}
+	return nil
+}
+
 // CutoffRule is a rule tranistioning shards off a given
 // cluster
 type CutoffRule struct {
-	ClusterName string   `protobuf:"bytes,1,opt,name=cluster_name" json:"cluster_name,omitempty"`
-	Shards      []uint32 `protobuf:"varint,2,rep,name=shards" json:"shards,omitempty"`
-	CutoffTime  int64    `protobuf:"varint,3,opt,name=cutoff_time" json:"cutoff_time,omitempty"`
+	ClusterName string    `protobuf:"bytes,1,opt,name=cluster_name" json:"cluster_name,omitempty"`
+	Shards      *ShardSet `protobuf:"bytes,2,opt,name=shards" json:"shards,omitempty"`
+	CutoffTime  int64     `protobuf:"varint,3,opt,name=cutoff_time" json:"cutoff_time,omitempty"`
 }
 
 func (m *CutoffRule) Reset()         { *m = CutoffRule{} }
 func (m *CutoffRule) String() string { return proto.CompactTextString(m) }
 func (*CutoffRule) ProtoMessage()    {}
+
+func (m *CutoffRule) GetShards() *ShardSet {
+	if m != nil {
+		return m.Shards
+	}
+	return nil
+}
 
 // ClusterMappingRuleSet is a set of cluster mapping rules built off a
 // particular version

--- a/generated/proto/schema/schema.proto
+++ b/generated/proto/schema/schema.proto
@@ -53,14 +53,14 @@ message Database {
 	int64 write_cutover_time = 6;
 	int64 cutover_complete_time = 7;
 	map<string, Cluster> clusters = 8;
-	map<string, ClusterShardAssignment> shard_assignments = 9;
+	map<string, ShardSet> shard_assignments = 9;
 	int32 version = 10;
 	repeated ClusterMappingRuleSet mapping_rules = 11;
 }
 
-// ClusterShardAssignment captures the shards currently assigned to a cluster
-message ClusterShardAssignment {
-	repeated uint32 shards = 1;
+// ShardSet is a bitset of shards
+message ShardSet {
+	repeated uint64 bits = 1;
 }
 
 // ClusterStatus is the status of a cluster
@@ -104,7 +104,7 @@ message ClusterDecommission {
 // CutoverRule is a rule transition shards onto a given cluster
 message CutoverRule {
 	string cluster_name = 1;
-	repeated uint32 shards = 2;
+	ShardSet shards = 2;
 	int64 read_cutover_time = 3;
 	int64 write_cutover_time = 4;
 }
@@ -113,7 +113,7 @@ message CutoverRule {
 // cluster
 message CutoffRule {
 	string cluster_name = 1;
-	repeated uint32 shards = 2;
+	ShardSet shards = 2;
 	int64 cutoff_time = 3;
 }
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d33e0758827a64fc016979f7ef7f1644845b340676bcb73c25e3634e6fc90e81
-updated: 2016-08-29T15:57:42.805854016-04:00
+hash: 0e125e32405c080c7c9886e2332745644f904ad0ff1766c243abf40e38645c07
+updated: 2016-08-30T14:00:55.17483371-04:00
 imports:
 - name: github.com/facebookgo/clock
   version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
@@ -29,4 +29,6 @@ imports:
   subpackages:
   - assert
   - require
+- name: github.com/willf/bitset
+  version: 1730870b454dde6756091d8c6a3d780ef123674c
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,6 +9,7 @@ import:
   subpackages:
   - assert
   - require    
+- package: github.com/willf/bitset
 - package: github.com/golang/mock    
 - package: github.com/m3db/m3x
   subpackages:


### PR DESCRIPTION
Required by a downstream PR to build the mapping rule sets that are actually used during query fan-out.

R: @xichen2020 @robskillington 
