### PR TITLE
[travis] Add go 1.7, 1.8 and 1.9 to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 go:
-  - 1.5
-  - 1.6
+  - 1.7
+  - 1.8
+  - 1.9
 install:
   - go get -v github.com/Masterminds/glide
   - glide install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.7
-  - 1.8
+  - 1.7.6
+  - 1.8.3
   - 1.9
 install:
   - go get -v github.com/Masterminds/glide


### PR DESCRIPTION
This PR adds Go 1.7, 1.8 and 1.9 to the versions of Go we test against in Travis.